### PR TITLE
Mostrar data de retorno no resumo diário de veículos

### DIFF
--- a/app/resumo-diario/page.tsx
+++ b/app/resumo-diario/page.tsx
@@ -28,6 +28,28 @@ const formatarHora = (date: Date | null) => {
   return format(date, 'HH:mm', { locale: ptBR });
 };
 
+const formatarIntervaloComRetorno = (
+  saidaDate: Date | null,
+  chegadaDate: Date | null,
+) => {
+  const inicio = formatarHora(saidaDate);
+  const fim = formatarHora(chegadaDate);
+
+  if (!saidaDate || !chegadaDate) {
+    return `${inicio} – ${fim}`;
+  }
+
+  const mesmoDia = format(saidaDate, 'yyyy-MM-dd') === format(chegadaDate, 'yyyy-MM-dd');
+
+  if (mesmoDia) {
+    return `${inicio} – ${fim}`;
+  }
+
+  const dataRetorno = format(chegadaDate, "dd/MM 'às' HH:mm", { locale: ptBR });
+
+  return `${inicio} – ${fim} (retorno em ${dataRetorno})`;
+};
+
 const ocorreNoDia = (agendamento: AgendamentoNormalizado, dia: Date) => {
   const startDay = startOfDay(dia);
   const endDay = endOfDay(dia);
@@ -454,7 +476,10 @@ export default function ResumoDiarioPage() {
                                   <div>
                                     <p className="text-xs font-semibold uppercase text-gray-500">Horário</p>
                                     <p className="text-base font-bold text-gray-900">
-                                      {formatarHora(agendamento.saidaDate)} – {formatarHora(agendamento.chegadaDate)}
+                                      {formatarIntervaloComRetorno(
+                                        agendamento.saidaDate,
+                                        agendamento.chegadaDate,
+                                      )}
                                     </p>
                                   </div>
                                   <div>


### PR DESCRIPTION
## Summary
- acrescenta formatação que exibe a data e hora de retorno quando o agendamento atravessa dias
- utiliza a nova formatação no card de horários do resumo diário

## Testing
- not run (lint requires interactive setup)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690defd8396883219a0db4059d9c49f5)