### PR TITLE
Adicionar gerenciamento de checklists e vinculação a veículos

### DIFF
--- a/app/checklists/page.tsx
+++ b/app/checklists/page.tsx
@@ -19,6 +19,8 @@ const criarPerguntaVazia = (): ChecklistQuestion => ({
   id: crypto.randomUUID ? crypto.randomUUID() : String(Date.now()),
   texto: '',
   obrigatorio: false,
+  tipoResposta: 'texto',
+  permiteObservacao: false,
 });
 
 export default function ChecklistsPage() {
@@ -315,6 +317,39 @@ export default function ChecklistsPage() {
                               className="w-full rounded-md border-gray-300 shadow-sm focus:border-green-500 focus:ring-green-500"
                               placeholder="Descreva a pergunta"
                             />
+
+                            <div className="grid gap-3 sm:grid-cols-2">
+                              <div>
+                                <label className="block text-xs font-medium text-gray-700">Tipo de resposta</label>
+                                <select
+                                  value={pergunta.tipoResposta}
+                                  onChange={(e) =>
+                                    atualizarPergunta(
+                                      pergunta.id,
+                                      'tipoResposta',
+                                      e.target.value as ChecklistQuestion['tipoResposta'],
+                                    )
+                                  }
+                                  className="mt-1 w-full rounded-md border-gray-300 shadow-sm focus:border-green-500 focus:ring-green-500"
+                                >
+                                  <option value="texto">Resposta curta</option>
+                                  <option value="numero">Número</option>
+                                  <option value="status">Menu de conformidade (C / NC / NA)</option>
+                                </select>
+                              </div>
+
+                              <div className="flex items-center justify-between rounded-md border border-gray-200 bg-white px-3 py-2 text-xs text-gray-700">
+                                <span>Permitir observação</span>
+                                <input
+                                  type="checkbox"
+                                  checked={Boolean(pergunta.permiteObservacao)}
+                                  onChange={(e) =>
+                                    atualizarPergunta(pergunta.id, 'permiteObservacao', e.target.checked)
+                                  }
+                                  className="rounded text-green-600 focus:ring-green-500"
+                                />
+                              </div>
+                            </div>
 
                             <div className="flex items-center justify-between text-sm">
                               <label className="inline-flex items-center gap-2 text-gray-700">

--- a/app/checklists/page.tsx
+++ b/app/checklists/page.tsx
@@ -1,0 +1,364 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import {
+  ChecklistModelo,
+  ChecklistQuestion,
+  atualizarChecklist,
+  criarChecklist,
+  listarChecklists,
+  removerChecklist,
+} from '@/app/lib/checklists';
+import ProtectedRoute from '../components/ProtectedRoute';
+import SidebarMenu from '../components/SidebarMenu';
+import { FiArrowDown, FiArrowUp, FiEdit2, FiPlus, FiTrash2 } from 'react-icons/fi';
+
+type ChecklistFormState = Omit<ChecklistModelo, 'id' | 'atualizadoEm'> & { id?: string };
+
+const criarPerguntaVazia = (): ChecklistQuestion => ({
+  id: crypto.randomUUID ? crypto.randomUUID() : String(Date.now()),
+  texto: '',
+  obrigatorio: false,
+});
+
+export default function ChecklistsPage() {
+  const [checklists, setChecklists] = useState<ChecklistModelo[]>([]);
+  const [carregando, setCarregando] = useState(true);
+  const [erro, setErro] = useState('');
+  const [checklistSelecionado, setChecklistSelecionado] = useState<ChecklistFormState | null>(null);
+
+  const checklistVazio: ChecklistFormState = useMemo(
+    () => ({
+      nome: '',
+      descricao: '',
+      perguntas: [criarPerguntaVazia()],
+    }),
+    [],
+  );
+
+  const carregarChecklists = async () => {
+    setCarregando(true);
+    setErro('');
+    try {
+      const lista = await listarChecklists();
+      setChecklists(lista);
+    } catch (error) {
+      console.error('Erro ao carregar checklists', error);
+      setErro('Não foi possível carregar os checklists. Tente novamente.');
+    } finally {
+      setCarregando(false);
+    }
+  };
+
+  useEffect(() => {
+    carregarChecklists();
+  }, []);
+
+  const iniciarCriacao = () => {
+    setChecklistSelecionado(checklistVazio);
+  };
+
+  const editarChecklist = (checklist: ChecklistModelo) => {
+    setChecklistSelecionado({
+      id: checklist.id,
+      nome: checklist.nome,
+      descricao: checklist.descricao ?? '',
+      perguntas: checklist.perguntas.length > 0 ? checklist.perguntas : [criarPerguntaVazia()],
+    });
+  };
+
+  const atualizarCampo = (campo: keyof ChecklistFormState, valor: string) => {
+    setChecklistSelecionado((anterior) => (anterior ? { ...anterior, [campo]: valor } : anterior));
+  };
+
+  const atualizarPergunta = (id: string, campo: keyof ChecklistQuestion, valor: string | boolean) => {
+    setChecklistSelecionado((anterior) => {
+      if (!anterior) return anterior;
+      return {
+        ...anterior,
+        perguntas: anterior.perguntas.map((pergunta) =>
+          pergunta.id === id ? { ...pergunta, [campo]: valor } : pergunta,
+        ),
+      };
+    });
+  };
+
+  const moverPergunta = (id: string, direcao: 'up' | 'down') => {
+    setChecklistSelecionado((anterior) => {
+      if (!anterior) return anterior;
+      const indice = anterior.perguntas.findIndex((p) => p.id === id);
+      if (indice === -1) return anterior;
+
+      const novaPosicao = direcao === 'up' ? indice - 1 : indice + 1;
+      if (novaPosicao < 0 || novaPosicao >= anterior.perguntas.length) return anterior;
+
+      const perguntas = [...anterior.perguntas];
+      const [selecionada] = perguntas.splice(indice, 1);
+      perguntas.splice(novaPosicao, 0, selecionada);
+
+      return { ...anterior, perguntas };
+    });
+  };
+
+  const adicionarPergunta = () => {
+    setChecklistSelecionado((anterior) =>
+      anterior
+        ? {
+            ...anterior,
+            perguntas: [...anterior.perguntas, criarPerguntaVazia()],
+          }
+        : anterior,
+    );
+  };
+
+  const removerPergunta = (id: string) => {
+    setChecklistSelecionado((anterior) => {
+      if (!anterior) return anterior;
+      const filtradas = anterior.perguntas.filter((p) => p.id !== id);
+      return { ...anterior, perguntas: filtradas.length > 0 ? filtradas : [criarPerguntaVazia()] };
+    });
+  };
+
+  const validarFormulario = (dados: ChecklistFormState): string => {
+    if (!dados.nome.trim()) return 'Informe um nome para o checklist.';
+    if (dados.perguntas.some((p) => !p.texto.trim())) return 'Todas as perguntas devem ter um enunciado.';
+    return '';
+  };
+
+  const salvarChecklist = async () => {
+    if (!checklistSelecionado) return;
+    const mensagemErro = validarFormulario(checklistSelecionado);
+    if (mensagemErro) {
+      setErro(mensagemErro);
+      return;
+    }
+
+    setErro('');
+    try {
+      if (checklistSelecionado.id) {
+        await atualizarChecklist(checklistSelecionado.id, {
+          nome: checklistSelecionado.nome,
+          descricao: checklistSelecionado.descricao,
+          perguntas: checklistSelecionado.perguntas,
+        });
+      } else {
+        await criarChecklist({
+          nome: checklistSelecionado.nome,
+          descricao: checklistSelecionado.descricao,
+          perguntas: checklistSelecionado.perguntas,
+        });
+      }
+      setChecklistSelecionado(null);
+      await carregarChecklists();
+    } catch (error) {
+      console.error('Erro ao salvar checklist', error);
+      setErro('Não foi possível salvar o checklist. Confira os dados e tente novamente.');
+    }
+  };
+
+  const excluirChecklist = async (checklist: ChecklistModelo) => {
+    if (!confirm(`Deseja remover o checklist "${checklist.nome}"?`)) return;
+    try {
+      await removerChecklist(checklist.id);
+      if (checklistSelecionado?.id === checklist.id) setChecklistSelecionado(null);
+      await carregarChecklists();
+    } catch (error) {
+      console.error('Erro ao remover checklist', error);
+      setErro('Não foi possível remover o checklist. Tente novamente.');
+    }
+  };
+
+  return (
+    <ProtectedRoute>
+      <div className="min-h-screen bg-gray-50 flex flex-col md:flex-row">
+        <SidebarMenu className="md:min-h-screen" />
+
+        <main className="flex-1 p-6 space-y-6">
+          <header className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+            <div>
+              <h1 className="text-3xl font-bold text-gray-800">Modelos de Checklist</h1>
+              <p className="text-gray-600">Cadastre e organize perguntas para aplicar aos veículos.</p>
+            </div>
+            <button
+              onClick={iniciarCriacao}
+              className="inline-flex items-center gap-2 rounded-lg bg-green-600 px-4 py-2 text-white shadow hover:bg-green-700"
+            >
+              <FiPlus /> Novo checklist
+            </button>
+          </header>
+
+          {erro && <div className="rounded-lg bg-red-50 border border-red-200 p-4 text-red-700">{erro}</div>}
+
+          <section className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+            <div className="space-y-4">
+              <div className="rounded-lg bg-white shadow border border-gray-200 p-4">
+                <div className="flex items-center justify-between mb-3">
+                  <h2 className="text-lg font-semibold text-gray-800">Checklists cadastrados</h2>
+                  {carregando && <span className="text-sm text-gray-500">Carregando...</span>}
+                </div>
+                {checklists.length === 0 && !carregando ? (
+                  <p className="text-gray-600">Nenhum checklist cadastrado até o momento.</p>
+                ) : (
+                  <ul className="divide-y divide-gray-100">
+                    {checklists.map((checklist) => (
+                      <li key={checklist.id} className="py-3 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                        <div>
+                          <p className="text-sm font-semibold text-gray-800">{checklist.nome}</p>
+                          <p className="text-xs text-gray-500">
+                            {checklist.perguntas.length} pergunta{checklist.perguntas.length === 1 ? '' : 's'} • Atualizado em{' '}
+                            {checklist.atualizadoEm
+                              ? new Date(checklist.atualizadoEm).toLocaleString('pt-BR')
+                              : '—'}
+                          </p>
+                        </div>
+                        <div className="flex items-center gap-3 text-sm">
+                          <button
+                            onClick={() => editarChecklist(checklist)}
+                            className="inline-flex items-center gap-1 text-green-700 hover:text-green-900"
+                          >
+                            <FiEdit2 /> Editar
+                          </button>
+                          <button
+                            onClick={() => excluirChecklist(checklist)}
+                            className="inline-flex items-center gap-1 text-red-700 hover:text-red-900"
+                          >
+                            <FiTrash2 /> Remover
+                          </button>
+                        </div>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </div>
+            </div>
+
+            <div>
+              <div className="rounded-lg bg-white shadow border border-gray-200 p-4">
+                <div className="flex items-center justify-between mb-4">
+                  <h2 className="text-lg font-semibold text-gray-800">
+                    {checklistSelecionado?.id ? 'Editar checklist' : 'Novo checklist'}
+                  </h2>
+                  {checklistSelecionado && (
+                    <button
+                      onClick={() => setChecklistSelecionado(null)}
+                      className="text-sm text-gray-600 hover:text-gray-800"
+                    >
+                      Cancelar
+                    </button>
+                  )}
+                </div>
+
+                {!checklistSelecionado ? (
+                  <p className="text-gray-600">Selecione um checklist existente ou clique em "Novo checklist".</p>
+                ) : (
+                  <div className="space-y-4">
+                    <div>
+                      <label className="block text-sm font-medium text-gray-700">Nome</label>
+                      <input
+                        value={checklistSelecionado.nome}
+                        onChange={(e) => atualizarCampo('nome', e.target.value)}
+                        className="mt-1 w-full rounded-md border-gray-300 shadow-sm focus:border-green-500 focus:ring-green-500"
+                        placeholder="Checklist de entrega"
+                      />
+                    </div>
+
+                    <div>
+                      <label className="block text-sm font-medium text-gray-700">Descrição</label>
+                      <textarea
+                        value={checklistSelecionado.descricao}
+                        onChange={(e) => atualizarCampo('descricao', e.target.value)}
+                        className="mt-1 w-full rounded-md border-gray-300 shadow-sm focus:border-green-500 focus:ring-green-500"
+                        placeholder="Orientações gerais ou observações"
+                        rows={2}
+                      />
+                    </div>
+
+                    <div className="space-y-3">
+                      <div className="flex items-center justify-between">
+                        <label className="text-sm font-medium text-gray-700">Perguntas</label>
+                        <button
+                          onClick={adicionarPergunta}
+                          className="inline-flex items-center gap-1 text-green-700 hover:text-green-900 text-sm"
+                        >
+                          <FiPlus /> Adicionar pergunta
+                        </button>
+                      </div>
+
+                      <div className="space-y-3">
+                        {checklistSelecionado.perguntas.map((pergunta, index) => (
+                          <div key={pergunta.id} className="rounded-lg border border-gray-200 p-3 bg-gray-50 space-y-2">
+                            <div className="flex items-center justify-between text-xs text-gray-500">
+                              <span>Pergunta {index + 1}</span>
+                              <div className="flex items-center gap-2">
+                                <button
+                                  onClick={() => moverPergunta(pergunta.id, 'up')}
+                                  className="p-1 rounded hover:bg-gray-200"
+                                  disabled={index === 0}
+                                  title="Mover para cima"
+                                >
+                                  <FiArrowUp />
+                                </button>
+                                <button
+                                  onClick={() => moverPergunta(pergunta.id, 'down')}
+                                  className="p-1 rounded hover:bg-gray-200"
+                                  disabled={index === checklistSelecionado.perguntas.length - 1}
+                                  title="Mover para baixo"
+                                >
+                                  <FiArrowDown />
+                                </button>
+                              </div>
+                            </div>
+
+                            <input
+                              value={pergunta.texto}
+                              onChange={(e) => atualizarPergunta(pergunta.id, 'texto', e.target.value)}
+                              className="w-full rounded-md border-gray-300 shadow-sm focus:border-green-500 focus:ring-green-500"
+                              placeholder="Descreva a pergunta"
+                            />
+
+                            <div className="flex items-center justify-between text-sm">
+                              <label className="inline-flex items-center gap-2 text-gray-700">
+                                <input
+                                  type="checkbox"
+                                  checked={pergunta.obrigatorio}
+                                  onChange={(e) => atualizarPergunta(pergunta.id, 'obrigatorio', e.target.checked)}
+                                  className="rounded text-green-600 focus:ring-green-500"
+                                />
+                                Obrigatória
+                              </label>
+                              <button
+                                onClick={() => removerPergunta(pergunta.id)}
+                                className="inline-flex items-center gap-1 text-red-700 hover:text-red-900"
+                              >
+                                <FiTrash2 /> Remover
+                              </button>
+                            </div>
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+
+                    <div className="flex justify-end gap-3">
+                      <button
+                        onClick={() => setChecklistSelecionado(null)}
+                        className="rounded-lg border border-gray-300 px-4 py-2 text-gray-700 hover:bg-gray-50"
+                      >
+                        Cancelar
+                      </button>
+                      <button
+                        onClick={salvarChecklist}
+                        className="rounded-lg bg-green-600 px-4 py-2 text-white hover:bg-green-700 shadow"
+                      >
+                        Salvar checklist
+                      </button>
+                    </div>
+                  </div>
+                )}
+              </div>
+            </div>
+          </section>
+        </main>
+      </div>
+    </ProtectedRoute>
+  );
+}

--- a/app/components/SidebarMenu.tsx
+++ b/app/components/SidebarMenu.tsx
@@ -46,6 +46,11 @@ const menuItems = [
     label: 'Histórico de Veículos',
     icon: 'M8 16h8m-4-4v8m8-8a8 8 0 11-16 0 8 8 0 0116 0z',
   },
+  {
+    href: '/checklists',
+    label: 'Modelos de Checklist',
+    icon: 'M5 13l4 4L19 7',
+  },
 ];
 
 export default function SidebarMenu({ className = '', onNavigate }: SidebarMenuProps) {

--- a/app/gerenciar-agendamentos/page.tsx
+++ b/app/gerenciar-agendamentos/page.tsx
@@ -599,7 +599,8 @@ export default function GerenciarAgendamentosPage() {
                       {agendamentosFiltrados.map((ag) => {
                         const status = getStatusAgendamento(ag);
                         const respostaChecklist = ag.id ? respostasPorAgendamento[ag.id] : null;
-                        const saidaConfirmada = respostaChecklist?.saidaConfirmada || ag.saidaConfirmada;
+                        const saidaConfirmada =
+                          !ag.concluido && (respostaChecklist?.saidaConfirmada || ag.saidaConfirmada);
                         const expandido = ag.id ? linhasExpandidas.has(ag.id) : false;
                         return (
                           <Fragment key={ag.id}>
@@ -816,11 +817,18 @@ export default function GerenciarAgendamentosPage() {
                           </p>
                           <p className="text-xs text-gray-500">Agendamento #{checklistSelecionado.agendamentoId}</p>
                         </div>
-                        {checklistSelecionado.saidaConfirmada && (
-                          <span className="px-3 py-1 rounded-full text-xs font-semibold bg-green-100 text-green-800 border border-green-200">
-                            Saída confirmada
-                          </span>
-                        )}
+                        {(() => {
+                          const agendamentoRelacionado = agendamentos.find(
+                            (ag) => ag.id === checklistSelecionado.agendamentoId,
+                          );
+                          const deveExibirTag =
+                            checklistSelecionado.saidaConfirmada && !agendamentoRelacionado?.concluido;
+                          return deveExibirTag ? (
+                            <span className="px-3 py-1 rounded-full text-xs font-semibold bg-green-100 text-green-800 border border-green-200">
+                              Saída confirmada
+                            </span>
+                          ) : null;
+                        })()}
                       </div>
 
                       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">

--- a/app/lib/agendamentos.ts
+++ b/app/lib/agendamentos.ts
@@ -14,6 +14,8 @@ export interface Agendamento {
   concluido: boolean;
   codigo?: string; // Número do comprovante
   nomeAgendador?: string; // Novo campo para responsável pelo agendamento
+  saidaConfirmada?: boolean;
+  checklistRespostaId?: string;
 }
 
 const getAgendamentosCollection = () => collection(getDb(), 'agendamentos');

--- a/app/lib/checklist-respostas.ts
+++ b/app/lib/checklist-respostas.ts
@@ -1,0 +1,73 @@
+import { addDoc, collection, doc, getDocs, query, updateDoc, where } from 'firebase/firestore';
+import { getDb } from './firebase';
+
+export interface RespostaPerguntaChecklist {
+  perguntaId: string;
+  perguntaTexto: string;
+  tipoResposta: 'texto' | 'numero' | 'status';
+  valor: string;
+  observacao?: string;
+}
+
+export interface ChecklistResposta {
+  id: string;
+  veiculoId: string;
+  agendamentoId: string;
+  checklistId: string;
+  respondidoPorNome?: string;
+  respondidoPorMatricula?: string;
+  respondidoEm: string;
+  saidaConfirmada?: boolean;
+  respostas: RespostaPerguntaChecklist[];
+}
+
+const getChecklistsRespostasCollection = () => collection(getDb(), 'checklistRespostas');
+
+export async function salvarRespostaChecklist(
+  dados: Omit<ChecklistResposta, 'id' | 'saidaConfirmada'> & { saidaConfirmada?: boolean },
+): Promise<string> {
+  const docRef = await addDoc(getChecklistsRespostasCollection(), {
+    ...dados,
+    saidaConfirmada: dados.saidaConfirmada ?? false,
+  });
+
+  return docRef.id;
+}
+
+export async function listarRespostasPorVeiculo(veiculoId: string): Promise<ChecklistResposta[]> {
+  if (!veiculoId) return [];
+
+  const filtro = query(getChecklistsRespostasCollection(), where('veiculoId', '==', veiculoId));
+  const snapshot = await getDocs(filtro);
+
+  const respostas = snapshot.docs.map((registro) => {
+    const data = registro.data();
+    return {
+      id: registro.id,
+      veiculoId: data.veiculoId,
+      agendamentoId: data.agendamentoId,
+      checklistId: data.checklistId,
+      respondidoPorNome: data.respondidoPorNome,
+      respondidoPorMatricula: data.respondidoPorMatricula,
+      respondidoEm: data.respondidoEm,
+      saidaConfirmada: data.saidaConfirmada ?? false,
+      respostas: Array.isArray(data.respostas)
+        ? data.respostas.map((resposta: any) => ({
+            perguntaId: resposta.perguntaId ?? '',
+            perguntaTexto: resposta.perguntaTexto ?? '',
+            tipoResposta: resposta.tipoResposta ?? 'texto',
+            valor: resposta.valor ?? '',
+            observacao: resposta.observacao ?? '',
+          }))
+        : [],
+    } as ChecklistResposta;
+  });
+
+  return respostas.sort((a, b) => new Date(b.respondidoEm).getTime() - new Date(a.respondidoEm).getTime());
+}
+
+export async function marcarSaidaConfirmada(respostaId: string): Promise<void> {
+  if (!respostaId) return;
+  const docRef = doc(getDb(), 'checklistRespostas', respostaId);
+  await updateDoc(docRef, { saidaConfirmada: true });
+}

--- a/app/lib/checklists.ts
+++ b/app/lib/checklists.ts
@@ -1,4 +1,4 @@
-import { addDoc, collection, deleteDoc, doc, getDocs, updateDoc } from 'firebase/firestore';
+import { addDoc, collection, deleteDoc, doc, getDoc, getDocs, updateDoc } from 'firebase/firestore';
 import { getDb } from './firebase';
 
 export interface ChecklistQuestion {
@@ -18,6 +18,31 @@ export interface ChecklistModelo {
 }
 
 const getChecklistsCollection = () => collection(getDb(), 'checklists');
+
+export async function buscarChecklistPorId(id: string): Promise<ChecklistModelo | null> {
+  if (!id) return null;
+
+  const registro = await getDoc(doc(getDb(), 'checklists', id));
+  if (!registro.exists()) return null;
+
+  const data = registro.data();
+
+  return {
+    id: registro.id,
+    nome: data.nome ?? 'Checklist sem nome',
+    descricao: data.descricao ?? '',
+    perguntas: Array.isArray(data.perguntas)
+      ? data.perguntas.map((pergunta: any, index: number) => ({
+          id: pergunta.id ?? String(index),
+          texto: pergunta.texto ?? '',
+          obrigatorio: pergunta.obrigatorio ?? false,
+          tipoResposta: pergunta.tipoResposta ?? 'texto',
+          permiteObservacao: pergunta.permiteObservacao ?? false,
+        }))
+      : [],
+    atualizadoEm: data.atualizadoEm ?? '',
+  };
+}
 
 export async function listarChecklists(): Promise<ChecklistModelo[]> {
   const snapshot = await getDocs(getChecklistsCollection());

--- a/app/lib/checklists.ts
+++ b/app/lib/checklists.ts
@@ -1,0 +1,67 @@
+import { addDoc, collection, deleteDoc, doc, getDocs, updateDoc } from 'firebase/firestore';
+import { getDb } from './firebase';
+
+export interface ChecklistQuestion {
+  id: string;
+  texto: string;
+  obrigatorio: boolean;
+}
+
+export interface ChecklistModelo {
+  id: string;
+  nome: string;
+  descricao?: string;
+  perguntas: ChecklistQuestion[];
+  atualizadoEm: string;
+}
+
+const getChecklistsCollection = () => collection(getDb(), 'checklists');
+
+export async function listarChecklists(): Promise<ChecklistModelo[]> {
+  const snapshot = await getDocs(getChecklistsCollection());
+
+  return snapshot.docs.map((registro) => {
+    const data = registro.data();
+
+    return {
+      id: registro.id,
+      nome: data.nome ?? 'Checklist sem nome',
+      descricao: data.descricao ?? '',
+      perguntas: Array.isArray(data.perguntas)
+        ? data.perguntas.map((pergunta: any, index: number) => ({
+            id: pergunta.id ?? String(index),
+            texto: pergunta.texto ?? '',
+            obrigatorio: pergunta.obrigatorio ?? false,
+          }))
+        : [],
+      atualizadoEm: data.atualizadoEm ?? '',
+    };
+  });
+}
+
+export async function criarChecklist(
+  dados: Omit<ChecklistModelo, 'id' | 'atualizadoEm'>,
+): Promise<string> {
+  const docRef = await addDoc(getChecklistsCollection(), {
+    ...dados,
+    atualizadoEm: new Date().toISOString(),
+  });
+
+  return docRef.id;
+}
+
+export async function atualizarChecklist(
+  id: string,
+  dados: Partial<Omit<ChecklistModelo, 'id'>>,
+): Promise<void> {
+  const docRef = doc(getDb(), 'checklists', id);
+  await updateDoc(docRef, {
+    ...dados,
+    atualizadoEm: new Date().toISOString(),
+  });
+}
+
+export async function removerChecklist(id: string): Promise<void> {
+  const docRef = doc(getDb(), 'checklists', id);
+  await deleteDoc(docRef);
+}

--- a/app/lib/checklists.ts
+++ b/app/lib/checklists.ts
@@ -5,6 +5,8 @@ export interface ChecklistQuestion {
   id: string;
   texto: string;
   obrigatorio: boolean;
+  tipoResposta: 'texto' | 'numero' | 'status';
+  permiteObservacao?: boolean;
 }
 
 export interface ChecklistModelo {
@@ -32,6 +34,8 @@ export async function listarChecklists(): Promise<ChecklistModelo[]> {
             id: pergunta.id ?? String(index),
             texto: pergunta.texto ?? '',
             obrigatorio: pergunta.obrigatorio ?? false,
+            tipoResposta: pergunta.tipoResposta ?? 'texto',
+            permiteObservacao: pergunta.permiteObservacao ?? false,
           }))
         : [],
       atualizadoEm: data.atualizadoEm ?? '',

--- a/app/lib/veiculos.ts
+++ b/app/lib/veiculos.ts
@@ -14,6 +14,7 @@ export interface Veiculo {
   placa: string;
   modelo: string;
   disponivel: boolean;
+  checklistId?: string;
 }
 
 export interface VeiculoComStatus extends Veiculo {
@@ -51,6 +52,7 @@ export async function listarVeiculos(): Promise<Veiculo[]> {
           placa: data.placa || '',
           modelo: data.modelo || '',
           disponivel: data.disponivel !== false,
+          checklistId: data.checklistId || '',
         } as Veiculo;
       })
       .filter((item): item is Veiculo => item !== null);
@@ -77,6 +79,7 @@ export async function buscarVeiculoPorId(id: string): Promise<Veiculo | null> {
     placa: data.placa || '',
     modelo: data.modelo || '',
     disponivel: data.disponivel !== false,
+    checklistId: data.checklistId || '',
   };
 }
 
@@ -122,6 +125,7 @@ export async function criarVeiculo(dados: Omit<Veiculo, 'id'>): Promise<string> 
       placa: dados.placa.toUpperCase(),
       modelo: dados.modelo,
       disponivel: dados.disponivel !== false,
+      checklistId: dados.checklistId || '',
     });
 
     return docRef.id;

--- a/app/veiculos/[veiculoId]/acesso/AgendamentoVeiculoClient.tsx
+++ b/app/veiculos/[veiculoId]/acesso/AgendamentoVeiculoClient.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { FormEvent, useEffect, useMemo, useState } from 'react';
-import { buscarAgendamentosPorVeiculoEMatricula, Agendamento } from '@/app/lib/agendamentos';
+import { buscarAgendamentosPorVeiculoEMatricula, atualizarAgendamento, Agendamento } from '@/app/lib/agendamentos';
 import { buscarChecklistPorId, ChecklistModelo } from '@/app/lib/checklists';
 import { salvarRespostaChecklist } from '@/app/lib/checklist-respostas';
 import { buscarVeiculoPorId, Veiculo } from '@/app/lib/veiculos';
@@ -154,13 +154,14 @@ export function AgendamentoVeiculoClient({ veiculoId }: ClientProps) {
 
     setSalvandoChecklist(true);
     try {
-      await salvarRespostaChecklist({
+      const respostaId = await salvarRespostaChecklist({
         veiculoId,
         agendamentoId: agendamentoSelecionado.id,
         checklistId: checklist.id,
         respondidoEm: new Date().toISOString(),
         respondidoPorNome: agendamentoSelecionado.motorista,
         respondidoPorMatricula: matricula.trim(),
+        saidaConfirmada: true,
         respostas: checklist.perguntas.map((pergunta) => ({
           perguntaId: pergunta.id,
           perguntaTexto: pergunta.texto,
@@ -172,7 +173,12 @@ export function AgendamentoVeiculoClient({ veiculoId }: ClientProps) {
         })),
       });
 
-      toast.success('Checklist enviado! Aguarde a confirmação da saída.');
+      await atualizarAgendamento(agendamentoSelecionado.id, {
+        saidaConfirmada: true,
+        checklistRespostaId: respostaId,
+      });
+
+      toast.success('Checklist enviado e saída confirmada!');
       setExibindoChecklist(false);
       setChecklist(null);
       setRespostasFormulario({});

--- a/app/veiculos/[veiculoId]/acesso/AgendamentoVeiculoClient.tsx
+++ b/app/veiculos/[veiculoId]/acesso/AgendamentoVeiculoClient.tsx
@@ -2,6 +2,8 @@
 
 import { FormEvent, useEffect, useMemo, useState } from 'react';
 import { buscarAgendamentosPorVeiculoEMatricula, Agendamento } from '@/app/lib/agendamentos';
+import { buscarChecklistPorId, ChecklistModelo } from '@/app/lib/checklists';
+import { salvarRespostaChecklist } from '@/app/lib/checklist-respostas';
 import { buscarVeiculoPorId, Veiculo } from '@/app/lib/veiculos';
 import { ToastContainer, toast } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
@@ -18,6 +20,12 @@ export function AgendamentoVeiculoClient({ veiculoId }: ClientProps) {
   const [carregandoBusca, setCarregandoBusca] = useState(false);
   const [selecionado, setSelecionado] = useState<string>('');
   const [erro, setErro] = useState('');
+  const [carregandoChecklist, setCarregandoChecklist] = useState(false);
+  const [checklist, setChecklist] = useState<ChecklistModelo | null>(null);
+  const [exibindoChecklist, setExibindoChecklist] = useState(false);
+  const [respostasFormulario, setRespostasFormulario] = useState<Record<string, { valor: string; observacao?: string }>>({});
+  const [errosChecklist, setErrosChecklist] = useState<Record<string, string>>({});
+  const [salvandoChecklist, setSalvandoChecklist] = useState(false);
 
   useEffect(() => {
     const carregarVeiculo = async () => {
@@ -84,9 +92,98 @@ export function AgendamentoVeiculoClient({ veiculoId }: ClientProps) {
     return true;
   };
 
-  const handleConfirmarSaida = () => {
+  const handleConfirmarSaida = async () => {
     if (!exigirSelecao()) return;
-    toast.success('Confirmação registrada! (ação visual por enquanto)');
+
+    if (!veiculo?.checklistId) {
+      toast.error('Este veículo não possui checklist atribuído.');
+      return;
+    }
+
+    setCarregandoChecklist(true);
+    try {
+      const encontrado = await buscarChecklistPorId(veiculo.checklistId);
+      if (!encontrado) {
+        toast.error('Checklist não encontrado para este veículo.');
+        return;
+      }
+
+      setChecklist(encontrado);
+      setRespostasFormulario({});
+      setErrosChecklist({});
+      setExibindoChecklist(true);
+    } catch (error) {
+      console.error('Erro ao carregar checklist:', error);
+      toast.error('Não foi possível abrir o checklist.');
+    } finally {
+      setCarregandoChecklist(false);
+    }
+  };
+
+  const atualizarResposta = (perguntaId: string, campo: 'valor' | 'observacao', valor: string) => {
+    setRespostasFormulario((anterior) => ({
+      ...anterior,
+      [perguntaId]: {
+        ...anterior[perguntaId],
+        [campo]: valor,
+      },
+    }));
+  };
+
+  const validarChecklist = () => {
+    if (!checklist) return false;
+    const novosErros: Record<string, string> = {};
+
+    checklist.perguntas.forEach((pergunta) => {
+      const resposta = respostasFormulario[pergunta.id]?.valor ?? '';
+      if (pergunta.obrigatorio && !resposta) {
+        novosErros[pergunta.id] = 'Campo obrigatório';
+      }
+    });
+
+    setErrosChecklist(novosErros);
+    return Object.keys(novosErros).length === 0;
+  };
+
+  const handleEnviarChecklist = async () => {
+    if (!checklist || !agendamentoSelecionado) return;
+    if (!validarChecklist()) {
+      toast.error('Preencha as perguntas obrigatórias para continuar.');
+      return;
+    }
+
+    setSalvandoChecklist(true);
+    try {
+      await salvarRespostaChecklist({
+        veiculoId,
+        agendamentoId: agendamentoSelecionado.id,
+        checklistId: checklist.id,
+        respondidoEm: new Date().toISOString(),
+        respondidoPorNome: agendamentoSelecionado.motorista,
+        respondidoPorMatricula: matricula.trim(),
+        respostas: checklist.perguntas.map((pergunta) => ({
+          perguntaId: pergunta.id,
+          perguntaTexto: pergunta.texto,
+          tipoResposta: pergunta.tipoResposta,
+          valor: respostasFormulario[pergunta.id]?.valor ?? '',
+          observacao: pergunta.permiteObservacao
+            ? respostasFormulario[pergunta.id]?.observacao?.trim() || ''
+            : '',
+        })),
+      });
+
+      toast.success('Checklist enviado! Aguarde a confirmação da saída.');
+      setExibindoChecklist(false);
+      setChecklist(null);
+      setRespostasFormulario({});
+      setErrosChecklist({});
+      setSelecionado('');
+    } catch (error) {
+      console.error('Erro ao salvar checklist:', error);
+      toast.error('Não foi possível salvar suas respostas. Tente novamente.');
+    } finally {
+      setSalvandoChecklist(false);
+    }
   };
 
   const handleCancelarAgendamento = () => {
@@ -232,15 +329,117 @@ export function AgendamentoVeiculoClient({ veiculoId }: ClientProps) {
               </button>
               <button
                 onClick={handleConfirmarSaida}
-                className="w-full sm:w-auto rounded-lg bg-green-600 px-4 py-2 text-white font-semibold hover:bg-green-700 transition"
+                disabled={carregandoChecklist}
+                className="w-full sm:w-auto rounded-lg bg-green-600 px-4 py-2 text-white font-semibold hover:bg-green-700 transition disabled:opacity-60"
               >
-                Confirmar saída
+                {carregandoChecklist ? 'Abrindo checklist...' : 'Confirmar saída'}
               </button>
             </div>
-            <p className="text-xs text-gray-500">As ações são apenas visuais nesta etapa inicial.</p>
+            <p className="text-xs text-gray-500">A saída só será confirmada após o envio do checklist.</p>
           </section>
         )}
       </div>
+
+      {exibindoChecklist && checklist && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-4">
+          <div className="bg-white rounded-xl shadow-xl w-full max-w-3xl max-h-[90vh] overflow-y-auto border border-gray-200">
+            <div className="flex items-start justify-between p-6 border-b border-gray-200">
+              <div>
+                <p className="text-sm text-gray-500">Checklist de saída</p>
+                <h2 className="text-2xl font-semibold text-gray-900">{checklist.nome}</h2>
+                <p className="text-sm text-gray-600 mt-1">
+                  Motorista: <strong>{agendamentoSelecionado?.motorista || 'Não informado'}</strong> • Matrícula:{' '}
+                  <strong>{matricula}</strong>
+                </p>
+              </div>
+              <button
+                onClick={() => setExibindoChecklist(false)}
+                className="text-gray-500 hover:text-gray-700"
+                aria-label="Fechar checklist"
+              >
+                ✕
+              </button>
+            </div>
+
+            <div className="p-6 space-y-5">
+              {checklist.perguntas.map((pergunta) => (
+                <div key={pergunta.id} className="border border-gray-200 rounded-lg p-4 space-y-3">
+                  <div className="flex items-start justify-between gap-3">
+                    <div>
+                      <p className="text-sm text-gray-600">Pergunta</p>
+                      <p className="font-semibold text-gray-900">{pergunta.texto || 'Pergunta sem texto'}</p>
+                    </div>
+                    {pergunta.obrigatorio && <span className="text-xs text-red-600 font-semibold">Obrigatória</span>}
+                  </div>
+
+                  {pergunta.tipoResposta === 'status' ? (
+                    <div className="flex flex-wrap gap-3">
+                      {[
+                        { valor: 'C', rotulo: 'Conforme' },
+                        { valor: 'NC', rotulo: 'Não conforme' },
+                        { valor: 'NA', rotulo: 'Não se aplica' },
+                      ].map((opcao) => (
+                        <button
+                          key={opcao.valor}
+                          type="button"
+                          onClick={() => atualizarResposta(pergunta.id, 'valor', opcao.valor)}
+                          className={`px-3 py-2 rounded-lg border font-semibold transition ${
+                            respostasFormulario[pergunta.id]?.valor === opcao.valor
+                              ? 'bg-green-600 text-white border-green-600'
+                              : 'bg-white text-gray-800 border-gray-300 hover:border-green-400'
+                          }`}
+                        >
+                          {opcao.rotulo} ({opcao.valor})
+                        </button>
+                      ))}
+                    </div>
+                  ) : (
+                    <input
+                      type={pergunta.tipoResposta === 'numero' ? 'number' : 'text'}
+                      value={respostasFormulario[pergunta.id]?.valor ?? ''}
+                      onChange={(event) => atualizarResposta(pergunta.id, 'valor', event.target.value)}
+                      className="w-full rounded-lg border border-gray-300 px-3 py-2 focus:border-green-500 focus:ring-2 focus:ring-green-200"
+                      placeholder={pergunta.tipoResposta === 'numero' ? 'Digite um número' : 'Resposta curta'}
+                    />
+                  )}
+
+                  {pergunta.permiteObservacao && (
+                    <div className="space-y-1">
+                      <label className="text-sm font-medium text-gray-700">Observação (opcional)</label>
+                      <textarea
+                        value={respostasFormulario[pergunta.id]?.observacao ?? ''}
+                        onChange={(event) => atualizarResposta(pergunta.id, 'observacao', event.target.value)}
+                        className="w-full rounded-lg border border-gray-300 px-3 py-2 focus:border-green-500 focus:ring-2 focus:ring-green-200"
+                        rows={2}
+                      />
+                    </div>
+                  )}
+
+                  {errosChecklist[pergunta.id] && (
+                    <p className="text-sm text-red-600">{errosChecklist[pergunta.id]}</p>
+                  )}
+                </div>
+              ))}
+
+              <div className="flex flex-col sm:flex-row sm:items-center sm:justify-end gap-3 pt-2">
+                <button
+                  onClick={() => setExibindoChecklist(false)}
+                  className="w-full sm:w-auto rounded-lg border border-gray-300 px-4 py-2 text-gray-700 font-semibold hover:bg-gray-100 transition"
+                >
+                  Cancelar
+                </button>
+                <button
+                  onClick={handleEnviarChecklist}
+                  disabled={salvandoChecklist}
+                  className="w-full sm:w-auto rounded-lg bg-green-600 px-4 py-2 text-white font-semibold hover:bg-green-700 transition disabled:opacity-60"
+                >
+                  {salvandoChecklist ? 'Enviando...' : 'Enviar checklist'}
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/app/veiculos/page.tsx
+++ b/app/veiculos/page.tsx
@@ -129,7 +129,6 @@ export default function VeiculosPage() {
     setConfirmandoSaida(resposta.id);
     try {
       await atualizarAgendamento(resposta.agendamentoId, {
-        concluido: true,
         saidaConfirmada: true,
         checklistRespostaId: resposta.id,
       });

--- a/app/veiculos/page.tsx
+++ b/app/veiculos/page.tsx
@@ -128,7 +128,11 @@ export default function VeiculosPage() {
 
     setConfirmandoSaida(resposta.id);
     try {
-      await atualizarAgendamento(resposta.agendamentoId, { concluido: true });
+      await atualizarAgendamento(resposta.agendamentoId, {
+        concluido: true,
+        saidaConfirmada: true,
+        checklistRespostaId: resposta.id,
+      });
       await marcarSaidaConfirmada(resposta.id);
       setRespostasChecklist((atuais) =>
         atuais.map((item) => (item.id === resposta.id ? { ...item, saidaConfirmada: true } : item)),

--- a/app/veiculos/page.tsx
+++ b/app/veiculos/page.tsx
@@ -3,11 +3,13 @@
 import { useEffect, useState } from 'react';
 import { listarVeiculos, criarVeiculo, removerVeiculo, atualizarVeiculo, Veiculo } from '@/app/lib/veiculos';
 import { listarChecklists, ChecklistModelo } from '@/app/lib/checklists';
+import { listarRespostasPorVeiculo, ChecklistResposta, marcarSaidaConfirmada } from '@/app/lib/checklist-respostas';
+import { atualizarAgendamento } from '@/app/lib/agendamentos';
 import { collection, getDocs } from 'firebase/firestore';
 import { getDb } from '@/app/lib/firebase';
 import ProtectedRoute from '../components/ProtectedRoute';
 import SidebarMenu from '../components/SidebarMenu';
-import { FiEdit2, FiTrash2, FiPlus, FiCheck, FiX, FiArrowUp, FiArrowDown, FiCopy } from 'react-icons/fi';
+import { FiEdit2, FiTrash2, FiPlus, FiCheck, FiX, FiArrowUp, FiArrowDown, FiCopy, FiEye } from 'react-icons/fi';
 
 export default function VeiculosPage() {
   const [veiculos, setVeiculos] = useState<Veiculo[]>([]);
@@ -26,6 +28,11 @@ export default function VeiculosPage() {
     direcao: 'asc',
   });
   const [baseUrl, setBaseUrl] = useState('');
+  const [respostasChecklist, setRespostasChecklist] = useState<ChecklistResposta[]>([]);
+  const [veiculoEmAnalise, setVeiculoEmAnalise] = useState<Veiculo | null>(null);
+  const [carregandoRespostas, setCarregandoRespostas] = useState(false);
+  const [erroRespostas, setErroRespostas] = useState('');
+  const [confirmandoSaida, setConfirmandoSaida] = useState<string | null>(null);
 
   const carregarVeiculos = async () => {
     setCarregando(true);
@@ -67,6 +74,12 @@ export default function VeiculosPage() {
     return `${origem}/veiculos/${veiculoId}/acesso`;
   };
 
+  const formatarDataHora = (valor: string) => {
+    const data = new Date(valor);
+    if (Number.isNaN(data.getTime())) return 'Data inválida';
+    return data.toLocaleString('pt-BR', { dateStyle: 'short', timeStyle: 'short' });
+  };
+
   const handleCopiarLink = async (veiculoId: string) => {
     const link = gerarLinkAcesso(veiculoId);
     if (!link) return;
@@ -81,6 +94,51 @@ export default function VeiculosPage() {
     } catch (error) {
       console.error('Erro ao copiar link:', error);
       setErro('Não foi possível copiar o link. Tente novamente.');
+    }
+  };
+
+  const abrirRespostasChecklist = async (veiculo: Veiculo) => {
+    if (!veiculo.id) return;
+    setVeiculoEmAnalise(veiculo);
+    setCarregandoRespostas(true);
+    setErroRespostas('');
+
+    try {
+      const respostas = await listarRespostasPorVeiculo(veiculo.id);
+      setRespostasChecklist(respostas);
+    } catch (error) {
+      console.error('Erro ao carregar respostas do checklist:', error);
+      setErroRespostas('Não foi possível carregar as respostas deste veículo.');
+    } finally {
+      setCarregandoRespostas(false);
+    }
+  };
+
+  const fecharModalRespostas = () => {
+    setVeiculoEmAnalise(null);
+    setRespostasChecklist([]);
+    setErroRespostas('');
+  };
+
+  const confirmarSaidaChecklist = async (resposta: ChecklistResposta) => {
+    if (!resposta.agendamentoId) {
+      setErroRespostas('Agendamento inválido para confirmação.');
+      return;
+    }
+
+    setConfirmandoSaida(resposta.id);
+    try {
+      await atualizarAgendamento(resposta.agendamentoId, { concluido: true });
+      await marcarSaidaConfirmada(resposta.id);
+      setRespostasChecklist((atuais) =>
+        atuais.map((item) => (item.id === resposta.id ? { ...item, saidaConfirmada: true } : item)),
+      );
+      alert('Saída confirmada com base no checklist preenchido.');
+    } catch (error) {
+      console.error('Erro ao confirmar saída via checklist:', error);
+      setErroRespostas('Erro ao confirmar a saída. Tente novamente.');
+    } finally {
+      setConfirmandoSaida(null);
     }
   };
 
@@ -412,6 +470,13 @@ export default function VeiculosPage() {
                         <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
                           <div className="flex space-x-3">
                             <button
+                              onClick={() => abrirRespostasChecklist(v)}
+                              className="text-blue-600 hover:text-blue-900"
+                              title="Verificar respostas do checklist"
+                            >
+                              <FiEye size={18} />
+                            </button>
+                            <button
                               onClick={() => handleEditar(v)}
                               className="text-green-600 hover:text-green-900"
                               title="Editar"
@@ -438,6 +503,90 @@ export default function VeiculosPage() {
           </div>
         </main>
       </div>
+
+      {veiculoEmAnalise && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-4">
+          <div className="bg-white rounded-xl shadow-xl w-full max-w-5xl max-h-[90vh] overflow-y-auto border border-gray-200">
+            <div className="flex items-start justify-between p-6 border-b border-gray-200">
+              <div>
+                <p className="text-sm text-gray-500">Respostas do checklist</p>
+                <h2 className="text-2xl font-semibold text-gray-900">{veiculoEmAnalise.modelo}</h2>
+                <p className="text-sm text-gray-600">Placa {veiculoEmAnalise.placa}</p>
+              </div>
+              <button
+                onClick={fecharModalRespostas}
+                className="text-gray-500 hover:text-gray-700"
+                aria-label="Fechar respostas do checklist"
+              >
+                ✕
+              </button>
+            </div>
+
+            <div className="p-6 space-y-4">
+              {erroRespostas && (
+                <div className="bg-red-50 border border-red-200 text-red-800 rounded-lg p-4">{erroRespostas}</div>
+              )}
+
+              {carregandoRespostas ? (
+                <div className="flex items-center gap-3 text-gray-600">
+                  <div className="h-4 w-4 border-2 border-green-600 border-t-transparent rounded-full animate-spin" />
+                  <span>Carregando respostas...</span>
+                </div>
+              ) : respostasChecklist.length === 0 ? (
+                <p className="text-sm text-gray-600">Nenhum checklist foi preenchido para este veículo.</p>
+              ) : (
+                <div className="space-y-4">
+                  {respostasChecklist.map((resposta) => (
+                    <div key={resposta.id} className="border border-gray-200 rounded-lg p-4 space-y-3">
+                      <div className="flex flex-col gap-1 sm:flex-row sm:items-start sm:justify-between">
+                        <div>
+                          <p className="text-sm text-gray-600">Respondido em {formatarDataHora(resposta.respondidoEm)}</p>
+                          <p className="font-semibold text-gray-900">
+                            {resposta.respondidoPorNome || 'Motorista não informado'} — Matrícula{' '}
+                            {resposta.respondidoPorMatricula || 'N/D'}
+                          </p>
+                          <p className="text-xs text-gray-500">Agendamento #{resposta.agendamentoId}</p>
+                        </div>
+                        <span
+                          className={`px-3 py-1 rounded-full text-xs font-semibold ${
+                            resposta.saidaConfirmada ? 'bg-green-100 text-green-800' : 'bg-yellow-100 text-yellow-800'
+                          }`}
+                        >
+                          {resposta.saidaConfirmada ? 'Saída confirmada' : 'Aguardando confirmação'}
+                        </span>
+                      </div>
+
+                      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                        {resposta.respostas.map((pergunta) => (
+                          <div key={`${resposta.id}-${pergunta.perguntaId}`} className="bg-gray-50 rounded-lg p-3 space-y-1">
+                            <p className="text-sm font-semibold text-gray-800">{pergunta.perguntaTexto}</p>
+                            <p className="text-sm text-gray-700">Resposta: {pergunta.valor}</p>
+                            {pergunta.observacao && (
+                              <p className="text-xs text-gray-600">Observação: {pergunta.observacao}</p>
+                            )}
+                          </div>
+                        ))}
+                      </div>
+
+                      {!resposta.saidaConfirmada && (
+                        <div className="flex justify-end">
+                          <button
+                            onClick={() => confirmarSaidaChecklist(resposta)}
+                            disabled={confirmandoSaida === resposta.id}
+                            className="inline-flex items-center gap-2 rounded-lg bg-green-600 px-4 py-2 text-white font-semibold hover:bg-green-700 transition disabled:opacity-60"
+                          >
+                            {confirmandoSaida === resposta.id ? 'Confirmando...' : 'Confirmar saída'}
+                          </button>
+                        </div>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
     </ProtectedRoute>
   );
 }


### PR DESCRIPTION
## Summary
- adiciona helpers de checklist no Firebase e uma página administrativa para criar, editar e reordenar perguntas
- inclui o menu de Modelos de Checklist no painel lateral
- permite escolher e exibir um checklist associado a cada veículo, persistindo no cadastro

## Testing
- npm run lint *(falhou por exigir configuração interativa do ESLint no ambiente)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6926f0b18df4832195f807a218598516)