### PR TITLE
Rastreamento veículos 3sat

### DIFF
--- a/app/api/3sat/route.ts
+++ b/app/api/3sat/route.ts
@@ -44,21 +44,28 @@ export async function POST(request: Request) {
       method === 'GET'
         ? await fetch(`${API_BASE_URL}${endpoint}?token=${encodeURIComponent(token)}`, {
             method: 'GET',
+            headers: {
+              Accept: 'application/json, text/plain;q=0.9, */*;q=0.8',
+            },
+            cache: 'no-store',
           })
         : await fetch(`${API_BASE_URL}${endpoint}`, {
             method: 'POST',
             headers: {
               'Content-Type': 'application/json',
+              Accept: 'application/json, text/plain;q=0.9, */*;q=0.8',
             },
-            body: JSON.stringify({ ...payload, Token: token }),
+            body: JSON.stringify({ ...payload, token }),
+            cache: 'no-store',
           });
 
     const rawText = await response.text();
     let data: unknown = rawText;
 
     if (rawText) {
+      const cleaned = rawText.replace(/^\uFEFF/, '').trim();
       try {
-        data = JSON.parse(rawText);
+        data = JSON.parse(cleaned);
       } catch (error) {
         console.warn('Resposta da 3SAT nao era JSON valido.', error);
       }

--- a/app/lib/3sat.ts
+++ b/app/lib/3sat.ts
@@ -5,14 +5,15 @@ export type Posicao3Sat = {
   driverName?: string;
   driverCode?: string;
   fleetName?: string;
-  latitude?: number;
-  longitude?: number;
-  speed?: number;
+  latitude?: number | string;
+  longitude?: number | string;
+  speed?: number | string;
   dateTime?: string;
   localDateTime?: string;
   address?: string;
   addressString?: string;
   plate?: string;
+  city?: string;
 };
 
 export type Dispositivo3Sat = {


### PR DESCRIPTION
Replicate 3SAT API fetching logic to correctly display vehicle locations on the `/rastreamento/3sat` page.

The previous implementation failed to show vehicle locations due to incorrect API call formatting (e.g., `Token` vs `token` in body, missing `Accept` headers, and lack of `no-store`) and the frontend not fetching and merging position data with the device list. This PR aligns the proxy and frontend fetching/processing with a known working system.

---
<a href="https://cursor.com/background-agent?bcId=bc-152dfe45-faa8-4bf4-8f77-a8d1a6d067e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-152dfe45-faa8-4bf4-8f77-a8d1a6d067e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

